### PR TITLE
Rework MSDOSSessionVenvLexer to use RegexLexer directly

### DIFF
--- a/naucse/markdown_util.py
+++ b/naucse/markdown_util.py
@@ -6,6 +6,8 @@ import mistune
 from jinja2 import Markup
 import pygments
 import pygments.lexers
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import Generic, Text, Comment
 import pygments.formatters.html
 
 
@@ -73,11 +75,21 @@ def style_space_after_prompt(html):
                   html)
 
 
-class MSDOSSessionVenvLexer(pygments.lexers.MSDOSSessionLexer):
-    """Lexer for simplistic MSDOS sessions with optional venvs."""
+class MSDOSSessionVenvLexer(RegexLexer):
+    """Lexer for simplistic MSDOS sessions with optional venvs.
+
+    Note that this doesn't use ``Name.Builtin`` (class="nb"), which naucse
+    styles the same as the rest of the command.
+    """
     name = 'MSDOS Venv Session'
     aliases = ['dosvenv']
-    _ps1rgx = r'^((?:\([_\w]+\))?\s?>\s?)(.*\n?)'
+    tokens = {
+        'root': [
+            (r'((?:\([_\w]+\))?\s?>\s?)([^#\n]*)(#.*)?',
+             bygroups(Generic.Prompt, Text, Comment)),
+            (r'(.+)', Generic.Output),
+        ]
+    }
 
 
 def get_lexer_by_name(lang):

--- a/test_naucse/test_markdown.py
+++ b/test_naucse/test_markdown.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+import html
 
 import pytest
 
@@ -234,15 +235,40 @@ def test_convert_with_prompt_spaces_console():
 
 
 @pytest.mark.parametrize('pre_prompt', ('', '(__venv__) ', '(env)'))
-def test_convert_with_dosvenv_prompt(pre_prompt):
+@pytest.mark.parametrize('space', ('', ' '))
+@pytest.mark.parametrize('command', ('python', '07:28 PM <DIR> Desktop'))
+def test_convert_with_dosvenv_prompt(pre_prompt, space, command):
     src = dedent("""
         ```dosvenv
-        {}> python
+        {}>{}{}
         ```
-    """).format(pre_prompt)
+    """).format(pre_prompt, space, command)
     expected = dedent("""
         <div class="highlight"><pre><span></span>
-        <span class="gp">{}&gt; </span>python
+        <span class="gp">{}&gt;{}</span>{}
         </pre></div>
-    """).strip().replace('\n', '').format(pre_prompt)
+    """).strip().replace('\n', '').format(pre_prompt, space, html.escape(command))
     assert convert_markdown(src).replace('\n', '') == expected
+
+def test_convert_full_dosvenv_prompt():
+    src = dedent(r"""
+        ```dosvenv
+        > whoami
+        helena
+        > venv\Scripts\activate  # activate virtualenv
+        (venv)> dir
+         Directory of C:\Users\helena
+        05/08/2014 07:28 PM <DIR>  Desktop
+        ```
+    """)
+    expected = dedent(r"""
+        <div class="highlight"><pre><span></span><span class="gp">&gt; </span>whoami
+        <span class="go">helena</span><span class="gp"></span>
+        <span class="gp">&gt; </span>venv\Scripts\activate  <span class="c"># activate virtualenv</span>
+        <span class="gp">(venv)&gt; </span>dir
+        <span class="go"> Directory of C:\Users\helena</span>
+        <span class="go">05/08/2014 07:28 PM &lt;DIR&gt;  Desktop</span>
+        </pre></div>
+    """).strip()
+    print(expected)
+    assert convert_markdown(src) == expected


### PR DESCRIPTION
I thought this would be a quick review, but after I wrote some tests on the train I couldn't resist updating the implementation along with the tests.
This version handles `>` in output (which happens when `dir` lists directories, as in one of the examples in naucse), and it styles comments. And it uses public API.

(It also adds weird empty spans sometimes, I don't know why but I don't think it's important.)